### PR TITLE
Circle-ci config for examples-go repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,19 @@ LDFLAGS += -extldflags "-static"
 endif
 
 .PHONY: all
-all: build check
+all: build test check
+
+.PHONY: test
+test:
+	$(GO) test ./...
+
+.PHONY: deps
+deps:
+	$(GO) get -d bazil.org/fuse
+	$(GO) get -d ./...
 
 .PHONY: build
-build: block_writer
+build: deps block_writer
 
 .PHONY: block_writer
 block_writer:

--- a/build/build-examples.sh
+++ b/build/build-examples.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Build a statically linked Cockroach binary
+#
+# Author: Peter Mattis (peter@cockroachlabs.com)
+
+set -euo pipefail
+
+# This is mildly tricky: This script runs itself recursively. The
+# first time it is run it does not take the if-branch below and
+# executes on the host computer. It uses the builder.sh script to run
+# itself inside of docker passing "docker" as the argument causing the
+# commands in the if-branch to be executed within the docker
+# container.
+if [ "${1-}" = "docker" ]; then
+    time make deps
+    time make STATIC=1 block_writer
+
+    # Make sure the created binary is statically linked.  Seems
+    # awkward to do this programmatically, but this should work.
+    file block_writer/block_writer | grep -F 'statically linked' > /dev/null
+
+    strip -S block_writer/block_writer
+    exit 0
+fi
+
+# Build the cockroach and test binaries.
+$(dirname $0)/builder.sh $0 docker

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -eu
+
+image="cockroachdb/builder"
+
+function init() {
+  docker build --tag="${image}" "$(dirname $0)"
+}
+
+if [ "${1-}" = "pull" ]; then
+  docker pull "${image}"
+  exit 0
+fi
+
+if [ "${1-}" = "init" ]; then
+  init
+  exit 0
+fi
+
+if [ "${1-}" = "push" ]; then
+  init
+  tag="$(date +%Y%m%d-%H%M%S)"
+  docker tag "${image}" "${image}:${tag}"
+  docker push "${image}"
+  exit 0
+fi
+
+gopath0="${GOPATH%%:*}"
+
+if [ "${CIRCLECI-}" = "true" ]; then
+  # HACK: Removal of docker containers fails on circleci with the
+  # error: "Driver btrfs failed to remove root filesystem". So if
+  # we're running on circleci, just leave the containers around.
+  rm=""
+else
+  rm="--rm"
+fi
+
+if [ -t 0 ]; then
+  tty="--tty"
+fi
+
+buildcache_dir="buildcache"
+uicache_dir="uicache"
+
+# Run our build container with a set of volumes mounted that will
+# allow the container to store persistent build data on the host
+# computer.
+#
+# This script supports both circleci and development hosts, so it must
+# support cases where the architecture inside the container is
+# different from that outside the container. We map /src/ directly
+# into the container because it is architecture-independent, and /pkg/
+# because every subdirectory is tagged with its architecture. We also
+# map certain subdirectories of ${GOPATH}/pkg into ${GOROOT}/pkg so
+# they can be used to cache race and netgo builds of the standard
+# library. /bin/ is mapped separately to avoid clobbering the host's
+# binaries. Note that the path used for the /bin/ mapping is also used
+# in the defaultBinary function of localcluster.go.
+#
+# -i causes some commands (including `git diff`) to attempt to use
+# a pager, so we override $PAGER to disable.
+docker run -i ${tty-} ${rm} \
+  --volume="${gopath0}/src:/go/src" \
+  --volume="${gopath0}/pkg:/go/pkg" \
+  --volume="${gopath0}/pkg/linux_amd64_netgo:/usr/src/go/pkg/linux_amd64_netgo" \
+  --volume="${gopath0}/pkg/linux_amd64_race:/usr/src/go/pkg/linux_amd64_race" \
+  --volume="${gopath0}/bin/linux_amd64:/go/bin" \
+  --volume="${HOME}/${buildcache_dir}:/${buildcache_dir}" \
+  --volume="${HOME}/${uicache_dir}:/${uicache_dir}" \
+  --volume="${PWD}:/go/src/github.com/cockroachdb/examples-go" \
+  --workdir="/go/src/github.com/cockroachdb/examples-go" \
+  --env="CACHE=/${buildcache_dir}" \
+  --env="PAGER=cat" \
+  --env="TSD_GITHUB_TOKEN=${TSD_GITHUB_TOKEN-}" \
+  "${image}" "$@"

--- a/build/circle-test.sh
+++ b/build/circle-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+builder=$(dirname $0)/builder.sh
+echo "make test"
+time ${builder} make test

--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Push binaries to AWS.
+# This is run by circle-ci after successful docker push.
+# Requisites:
+# - binaries must be statically linked
+# - circleci must have AWS credentials configured
+# - AWS credentials must have S3 write permissions on the bucket
+# - the aws cli must be installed on the machine
+# - the region must be configured
+#
+# Ask marc@cockroachlabs.com for the aws credentials file to use, then follow the
+# steps in circle.yml to configure aws and generate the binaries.
+
+set -eux
+
+BUCKET_PATH="cockroachdb/bin"
+LATEST_SUFFIX=".LATEST"
+
+now=$(date +"%Y%m%d-%H%M%S")
+today=$(echo ${now} | cut -d '-' -f1)
+binary_suffix=".${now}.${CIRCLE_SHA1-$(git rev-parse HEAD)}"
+
+# push_one_binary takes the path to the binary inside the cockroach repo.
+# eg: push_one_binary sql/sql.test
+# The file will be pushed to: s3://BUCKET_PATH/sql.test.YYMMDD-HHMMSS.CIRCLESHA1
+# The S3 basename will be stored in s3://BUCKET_PATH/sql.test.LATEST
+function push_one_binary {
+  rel_path=$1
+  binary_name=$(basename $1)
+
+  # Fetch name of most recent binary.
+  # TODO(marc): some versions of `aws s3 cp` allow - for stdin/stdout, but not all.
+  tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
+  # Don't exit on errors, clearing the latest file is an easy way to force multiple uploads.
+  time aws s3 cp s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX} ${tmpfile} || true
+  contents=$(cat ${tmpfile})
+  rm -f ${tmpfile}
+  latest_date=$(echo ${contents} | sed "s/${binary_name}.\([0-9]\+\)-.*/\1/")
+
+  if [ "${latest_date}" == "${today}" ]; then
+    echo "Latest binary is from today, skipping: ${contents}"
+    exit 0
+  fi
+
+  # Latest file did not exist, was empty, or pointed to an old binary.
+  # Upload binary.
+  cd $(dirname $0)/..
+  time aws s3 cp ${rel_path} s3://${BUCKET_PATH}/${binary_name}${binary_suffix}
+
+  # Upload LATEST file.
+  tmpfile=$(mktemp /tmp/cockroach-push.XXXXXX)
+  echo ${binary_name}${binary_suffix} > ${tmpfile}
+  time aws s3 cp ${tmpfile} s3://${BUCKET_PATH}/${binary_name}${LATEST_SUFFIX}
+  rm -f ${tmpfile}
+}
+
+push_one_binary block_writer/block_writer

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - make deps
+
+test:
+  override:
+    - build/circle-test.sh
+
+deployment:
+  aws:
+    branch: master
+    commands:
+      - aws configure set region us-east-1
+      - build/build-examples.sh
+      - build/push-aws.sh


### PR DESCRIPTION
Performs the following:
* go get dependencies
* run all tests (only in filesystem/ for now, investigating flakiness)
* build static block_writer example
* push block_writer binary to AWS

This is much dumber than the cockroachdb logic. Among others:
* dependencies are only fetched through go get
* make check cannot run on circle-ci due to missing commands

I do prefer keeping the dependencies more dynamic, since examples are
the kinds of things that should work out of the box.