### PR TITLE
Remove testserver from block_writer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,15 @@ deps:
 	$(GO) get -d ./...
 
 .PHONY: build
-build: deps block_writer
+build: deps block_writer fakerealtime
 
 .PHONY: block_writer
 block_writer:
 	$(GO) build -tags '$(TAGS)' $(GOFLAGS) -ldflags '$(LDFLAGS)' -v -i -o block_writer/block_writer ./block_writer
+
+.PHONY: fakerealtime
+fakerealtime:
+	$(GO) build -tags '$(TAGS)' $(GOFLAGS) -ldflags '$(LDFLAGS)' -v -i -o fakerealtime/fakerealtime ./fakerealtime
 
 .PHONY: check
 check:

--- a/block_writer/README.md
+++ b/block_writer/README.md
@@ -1,0 +1,38 @@
+# Block writer example
+
+## Summary
+
+The block writer example program is a write-only workload intended to insert
+a large amount of data into cockroach quickly. This example is intended to
+trigger range splits and rebalances.
+
+## Running
+
+Run against an existing cockroach node or cluster.
+
+#### Development node
+```
+# Build cockroach binary from https://github.com/cockroachdb/cockroach
+# Start it in dev mode (listens on localhost:26257)
+./cockroach start --dev
+
+# Build block_writer example.
+# Start it with:
+./block_writer --db-url=http://localhost:26257
+```
+
+#### Insecure node or cluster
+```
+# Launch your node or cluster in insecure mode (with --insecure passed to cockroach).
+# Find a reachable address: [mycockroach:26257].
+# Run the block writer with:
+./block_writer --db-url=http://mycockroach:26257
+```
+
+#### Secure node or cluster
+```
+# Launch your node or cluster in secure mode with certificates in [mycertsdir]
+# Find a reachable address:[mycockroach:26257].
+# Run the block writer with:
+./block_writer --db-url=https://mycockroach:26257/?certs=mycertsdir
+```

--- a/fakerealtime/README.md
+++ b/fakerealtime/README.md
@@ -1,10 +1,12 @@
-# Block writer example
+# Fake Real Time example
 
 ## Summary
 
-The block writer example program is a write-only workload intended to insert
-a large amount of data into cockroach quickly. This example is intended to
-trigger range splits and rebalances.
+This example uses a log-style table in an approximation of the
+"fake real time" system used at Friendfeed. Two tables are used: a
+`messages` table stores the complete data for all messages
+organized by channel, and a global `updates` table stores metadata
+about recently-updated channels.
 
 ## Running
 
@@ -16,9 +18,9 @@ Run against an existing cockroach node or cluster.
 # Start it in dev mode (listens on localhost:26257)
 ./cockroach start --dev
 
-# Build block_writer example.
+# Build fakerealtime example.
 # Start it with:
-./block_writer --db-url=http://localhost:26257
+./fakerealtime --db-url=http://localhost:26257
 ```
 
 #### Insecure node or cluster
@@ -26,7 +28,7 @@ Run against an existing cockroach node or cluster.
 # Launch your node or cluster in insecure mode (with --insecure passed to cockroach).
 # Find a reachable address: [mycockroach:26257].
 # Run the example with:
-./block_writer --db-url=http://mycockroach:26257
+./fakerealtime --db-url=http://mycockroach:26257
 ```
 
 #### Secure node or cluster
@@ -34,5 +36,5 @@ Run against an existing cockroach node or cluster.
 # Launch your node or cluster in secure mode with certificates in [mycertsdir]
 # Find a reachable address:[mycockroach:26257].
 # Run the example with:
-./block_writer --db-url=https://mycockroach:26257/?certs=mycertsdir
+./fakerealtime --db-url=https://mycockroach:26257/?certs=mycertsdir
 ```

--- a/fakerealtime/main.go
+++ b/fakerealtime/main.go
@@ -54,9 +54,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/cockroach/security"
-	"github.com/cockroachdb/cockroach/security/securitytest"
-	"github.com/cockroachdb/cockroach/server"
+	_ "github.com/cockroachdb/cockroach/sql/driver"
 	"github.com/cockroachdb/cockroach/util/log"
 	"github.com/montanaflynn/stats"
 )
@@ -190,19 +188,15 @@ func main() {
 	var dbDriver string
 	flag.StringVar(&dbDriver, "db-driver", "cockroach", "database driver to use")
 	var dbAddr string
-	flag.StringVar(&dbAddr, "db-addr", "", "database address. defaults to ephemeral cockroach instance")
+	flag.StringVar(&dbAddr, "db-url", "", "URL to connect to a running database.")
 
 	numChannels := flag.Int("num-channels", 100, "number of channels")
 	numWriters := flag.Int("num-writers", 2, "number of writers")
 	flag.Parse()
 
 	if dbAddr == "" {
-		security.SetReadFileFn(securitytest.Asset)
-		srv := server.StartTestServer(nil)
-		defer srv.Stop()
-
-		dbDriver = "cockroach"
-		dbAddr = fmt.Sprintf("https://root@%s?certs=test_certs", srv.ServingAddr())
+		log.Errorf("--db-url flag is required")
+		return
 	}
 	db, err := sql.Open(dbDriver, dbAddr)
 	if err != nil {


### PR DESCRIPTION
A running cockroach node or cluster is required.
Added readme with instructions on how to run it against:
* single dev node
* insecure node or cluster
* secure node or cluster

My plan is to do this for all examples. Specifically:
* no more dependency on cockroach/server (makes binaries and compile
  times huge)
* identical flags (`--db-url`, although I may change this)
* readme with short description and usage