### PR TITLE
Switch to cockroachdb/pq driver.

### DIFF
--- a/bank/main.go
+++ b/bank/main.go
@@ -27,7 +27,8 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/lib/pq"
+	// Import postgres driver.
+	_ "github.com/cockroachdb/pq"
 )
 
 var maxTransfer = flag.Int("max-transfer", 999, "Maximum amount to transfer in one transaction.")

--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -31,9 +31,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	_ "github.com/lib/pq"
-
 	"github.com/satori/go.uuid"
+	// Import postgres driver.
+	_ "github.com/cockroachdb/pq"
 )
 
 const (

--- a/fakerealtime/main.go
+++ b/fakerealtime/main.go
@@ -56,9 +56,9 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/lib/pq"
-
 	"github.com/montanaflynn/stats"
+	// Import postgres driver.
+	_ "github.com/cockroachdb/pq"
 )
 
 func createTables(db *sql.DB) error {

--- a/filesystem/main.go
+++ b/filesystem/main.go
@@ -61,7 +61,7 @@ import (
 	"bazil.org/fuse/fs"
 	_ "bazil.org/fuse/fs/fstestutil"
 	// Import postgres driver.
-	_ "github.com/lib/pq"
+	_ "github.com/cockroachdb/pq"
 )
 
 var usage = func() {

--- a/photos/db.go
+++ b/photos/db.go
@@ -24,7 +24,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/util"
-	_ "github.com/lib/pq"
+	// Import postgres driver.
+	_ "github.com/cockroachdb/pq"
 )
 
 const (


### PR DESCRIPTION
Technically, only the filesystem example needs it since the tests import
the testserver, causing double registration of the postgres driver.

However, better be consistent and avoid a surprise for anyone adding
tests to the other examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/48)
<!-- Reviewable:end -->
