### PR TITLE
make static builds work again without docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ ifeq ($(STATIC),1)
 # The netgo build tag instructs the net package to try to build a
 # Go-only resolver.
 TAGS += netgo
+# The installsuffix makes sure we actually get the netgo build, see
+# https://github.com/golang/go/issues/9369#issuecomment-69864440
+GOFLAGS += -installsuffix netgo
 LDFLAGS += -extldflags "-static"
 endif
 

--- a/build/build-examples.sh
+++ b/build/build-examples.sh
@@ -3,14 +3,11 @@
 #
 # Author: Peter Mattis (peter@cockroachlabs.com)
 
-set -euo pipefail
+set -eux
 
 time make deps
 time make STATIC=1 block_writer
 time make STATIC=1 photos
 
-# Make sure the created binary is statically linked.  Seems
-# awkward to do this programmatically, but this should work.
-file block_writer/block_writer | grep -F 'statically linked' > /dev/null
-
 strip -S block_writer/block_writer
+strip -S photos/photos

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,11 @@
 machine:
+  environment:
+    GOROOT: ${HOME}/go
+    PATH: ${PATH}:${HOME}/go/bin
   post:
     - sudo rm -rf /usr/local/go
     - if [ ! -e go1.6.linux-amd64.tar.gz ]; then curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz; fi
-    - sudo tar -C /usr/local -xzf go1.6.linux-amd64.tar.gz
+    - tar -C ${HOME} -xzf go1.6.linux-amd64.tar.gz
 
 dependencies:
   override:


### PR DESCRIPTION
* local go install (the netgo suffix causes permission denied)
* don't check for "statically linked", they aren't.
* also strip photos binary

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/52)
<!-- Reviewable:end -->
