### PR TITLE
Default --concurrency to 2*runtime.NumCPU()

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -41,7 +42,7 @@ const (
 )
 
 // concurrency = number of concurrent insertion processes.
-var concurrency = flag.Int("concurrency", 3, "Number of concurrent writers inserting blocks")
+var concurrency = flag.Int("concurrency", 2*runtime.NumCPU(), "Number of concurrent writers inserting blocks")
 
 var tolerateErrors = flag.Bool("tolerate-errors", false, "Keep running on error")
 


### PR DESCRIPTION
The previous default of 3 was insufficient to drive sustained load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/69)
<!-- Reviewable:end -->
