### PR TITLE
block_writer: set max idle conns

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -130,6 +130,7 @@ func setupDatabase(dbURL string) (*sql.DB, error) {
 
 	// Allow a maximum of concurrency+1 connections to the database.
 	db.SetMaxOpenConns(*concurrency + 1)
+	db.SetMaxIdleConns(*concurrency + 1)
 
 	// Create the initial table for storing blocks.
 	if _, err := db.Exec(`


### PR DESCRIPTION
Avoid closing idle connections immediately by setting max idle conns to
the same value as max open conns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/70)
<!-- Reviewable:end -->
