### PR TITLE
Mostly fix CircleCI problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,11 @@ test:
 
 .PHONY: deps
 deps:
-	$(GO) get -u -d bazil.org/fuse
-	$(GO) get -u -d -t ./...
+	-DEPS=$$($(GO) list -f '{{ range .Imports}}{{ println . }}{{end}}{{ range .TestImports}}{{ println . }}{{end}}{{ range .XTestImports}}{{ println . }}{{end}}' ./... | \
+	  sort -u | egrep '\.(org|com)/' | \
+	  grep -v cockroachdb/examples-go); \
+	  echo $${DEPS}; \
+	  $(GO) get -u -d $${DEPS}
 
 .PHONY: build
 build: deps block_writer fakerealtime filesystem bank photos

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ test:
 
 .PHONY: deps
 deps:
-	$(GO) get -d bazil.org/fuse
-	$(GO) get -d -t ./...
+	$(GO) get -u -d bazil.org/fuse
+	$(GO) get -u -d -t ./...
 
 .PHONY: build
 build: deps block_writer fakerealtime filesystem bank photos

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,16 @@ machine:
     - if [ ! -e go1.6.2.linux-amd64.tar.gz ]; then curl -O https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz; fi
     - tar -C ${HOME} -xzf go1.6.2.linux-amd64.tar.gz
 
+checkout:
+  post:
+    - rm -rf           "${GOPATH%%:*}/src/github.com/cockroachdb/examples-go"
+    - mkdir -p         "${GOPATH%%:*}/src/github.com/cockroachdb/"
+    - mv ~/examples-go "${GOPATH%%:*}/src/github.com/cockroachdb/"
+    - ln -s            "${GOPATH%%:*}/src/github.com/cockroachdb/examples-go" ~/examples-go
+
 dependencies:
   override:
-    - make deps
+    - make -C "${GOPATH%%:*}/src/github.com/cockroachdb/examples-go" deps
   cache_directories:
     - ~/go1.6.2.linux-amd64.tar.gz
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,14 +4,14 @@ machine:
     PATH: ${PATH}:${HOME}/go/bin
   post:
     - sudo rm -rf /usr/local/go
-    - if [ ! -e go1.6.linux-amd64.tar.gz ]; then curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz; fi
-    - tar -C ${HOME} -xzf go1.6.linux-amd64.tar.gz
+    - if [ ! -e go1.6.2.linux-amd64.tar.gz ]; then curl -O https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz; fi
+    - tar -C ${HOME} -xzf go1.6.2.linux-amd64.tar.gz
 
 dependencies:
   override:
     - make deps
   cache_directories:
-    - ~/go1.6.linux-amd64.tar.gz
+    - ~/go1.6.2.linux-amd64.tar.gz
 
 test:
   override:


### PR DESCRIPTION
Retrieval of dependencies now works correctly, but the builds are still
failing because of an upstream failure with
`github.com/opentracing/basictracer-go`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/71)

<!-- Reviewable:end -->
