### PR TITLE
photos: add benchmark output to photos

### DIFF
--- a/photos/user.go
+++ b/photos/user.go
@@ -68,6 +68,7 @@ var ops = []*opDesc{
 
 var stats struct {
 	sync.Mutex
+	start     time.Time
 	computing bool
 	totalOps  int
 	noUserOps int
@@ -78,6 +79,7 @@ var stats struct {
 
 func init() {
 	stats.hist = hdrhistogram.New(0, 0x7fffffff, 1)
+	stats.start = time.Now()
 	stats.opCounts = map[int]int{}
 
 	// Compute the total of all op relative frequencies.


### PR DESCRIPTION
Upon termination, `photos` now outputs Go benchmark stats. The benchmark
name must be passed in through the new `--benchmark-name` flag, because
only the continuous load tester framework knows the intended duration of
the test (which should be included in the benchmark name).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/74)
<!-- Reviewable:end -->
