### PR TITLE
photos: Avoid inserting comments with empty photo IDs 

### DIFF
--- a/photos/user.go
+++ b/photos/user.go
@@ -43,8 +43,8 @@ const (
 	listCommentsOp
 	updatePhotoOp
 	updateCommentOp
-	deletePhotoOp
 	deleteCommentOp
+	deletePhotoOp
 )
 
 type opDesc struct {
@@ -54,6 +54,10 @@ type opDesc struct {
 	normFreq float64
 }
 
+// Note that tests care about the order here: running each command
+// once in this order is expected to succeed (so users must be created
+// before photos which must be created before comments, with deletion in
+// the reverse order).
 var ops = []*opDesc{
 	{createUserOp, "create user", 1, 0},
 	{createPhotoOp, "create photo", 10, 0},
@@ -62,19 +66,20 @@ var ops = []*opDesc{
 	{listCommentsOp, "list comments", 20, 0},
 	{updatePhotoOp, "update photo", 2.5, 0},
 	{updateCommentOp, "update comment", 5, 0},
-	{deletePhotoOp, "delete photo", 1.25, 0},
 	{deleteCommentOp, "delete comment", 2.5, 0},
+	{deletePhotoOp, "delete photo", 1.25, 0},
 }
 
 var stats struct {
 	sync.Mutex
-	start     time.Time
-	computing bool
-	totalOps  int
-	noUserOps int
-	failedOps int
-	hist      *hdrhistogram.Histogram
-	opCounts  map[int]int
+	start      time.Time
+	computing  bool
+	totalOps   int
+	noUserOps  int
+	noPhotoOps int
+	failedOps  int
+	hist       *hdrhistogram.Histogram
+	opCounts   map[int]int
 }
 
 func init() {
@@ -115,7 +120,7 @@ func startStats(stopper *stop.Stopper) {
 		case <-ticker.C:
 			stats.Lock()
 			opsPerSec := float64(stats.totalOps-lastOps) / float64(statsInterval/1E9)
-			log.Printf("%d ops, %d no-user, %d errs (%.2f/s)", stats.totalOps, stats.noUserOps, stats.failedOps, opsPerSec)
+			log.Printf("%d ops, %d no-user, %d no-photo, %d errs (%.2f/s)", stats.totalOps, stats.noUserOps, stats.noPhotoOps, stats.failedOps, opsPerSec)
 			lastOps = stats.totalOps
 			stats.Unlock()
 		case <-stopper.ShouldStop():
@@ -146,6 +151,8 @@ func startUser(ctx Context, stopper *stop.Stopper) {
 			switch {
 			case err == errNoUser:
 				stats.noUserOps++
+			case err == errNoPhoto:
+				stats.noPhotoOps++
 			case err != nil:
 				stats.failedOps++
 				log.Printf("failed to run %s op for %d: %s", op.name, userID, err)

--- a/photos/user_test.go
+++ b/photos/user_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Ben Darnell
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach-go/testserver"
+)
+
+func initTestDB(t *testing.T, numUsers int) (Context, func()) {
+	db, stop := testserver.NewDBForTestWithDatabase(t, "photos")
+	if err := initSchema(db); err != nil {
+		stop()
+		t.Fatal(err)
+	}
+	ctx := Context{
+		DB:       db,
+		NumUsers: numUsers,
+	}
+	return ctx, stop
+}
+
+// TestAllOps runs every operation once and ensures that they complete
+// without error.
+func TestAllOps(t *testing.T) {
+	ctx, stop := initTestDB(t, 1)
+	defer stop()
+
+	for _, op := range ops {
+		if err := runUserOp(ctx, 1, op.typ); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/photos/user_test.go
+++ b/photos/user_test.go
@@ -43,8 +43,24 @@ func TestAllOps(t *testing.T) {
 	defer stop()
 
 	for _, op := range ops {
+		t.Logf("running %s", op.name)
 		if err := runUserOp(ctx, 1, op.typ); err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestCommentWithoutPhotos(t *testing.T) {
+	ctx, stop := initTestDB(t, 1)
+	defer stop()
+
+	if err := runUserOp(ctx, 1, createUserOp); err != nil {
+		t.Error(err)
+	}
+
+	if err := runUserOp(ctx, 1, createCommentOp); err == nil {
+		t.Error("unexpected success creating comment with no photos")
+	} else if err != errNoPhoto {
+		t.Errorf("expected errNoPhoto, got %s", err)
 	}
 }


### PR DESCRIPTION
Comments for the empty photo ID will have very high contention,
eventually bringing the process to a standstill.

Explicitly check for this case, and add a CHECK constraint to the schema
to ensure that any empty UUIDs that make it through to the database will
be rejected.

Updates cockroachdb/cockroach#9247

@cockroachdb/stability

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/78)
<!-- Reviewable:end -->
