### PR TITLE
block_writer: show lifetime queries/sec

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -243,6 +243,11 @@ func main() {
 			fmt.Printf("%6s: %6.1f/sec",
 				time.Duration(time.Since(start).Seconds()+0.5)*time.Second,
 				float64(dumps-lastNumDumps)/elapsed.Seconds())
+			if *duration > 0 || *maxBlocks > 0 {
+				// If the duration or max-blocks are limited, show the average
+				// performance since starting.
+				fmt.Printf("  %6.1f/sec", float64(dumps)/time.Since(start).Seconds())
+			}
 			if numErr > 0 {
 				fmt.Printf(" (%d total errors)", numErr)
 			}


### PR DESCRIPTION
Output lifetime queries/sec if the duration or max-blocks are limited.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/80)
<!-- Reviewable:end -->
