### PR TITLE
Add -batch command line flag to block_writer

### DIFF
--- a/photos/main.go
+++ b/photos/main.go
@@ -29,7 +29,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/spf13/cobra"
 )
 

--- a/photos/user.go
+++ b/photos/user.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
-	"github.com/cockroachdb/cockroach/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/codahale/hdrhistogram"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
The value of this flag controls how many blocks to insert with each SQL
statement. This feature is meant to help stress the parallelizing dist
sender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/81)
<!-- Reviewable:end -->
