### PR TITLE
Stop specifying netgo on static builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,6 @@ GOFLAGS :=
 STATIC :=
 
 ifeq ($(STATIC),1)
-# The netgo build tag instructs the net package to try to build a
-# Go-only resolver.
-TAGS += netgo
-# The installsuffix makes sure we actually get the netgo build, see
-# https://github.com/golang/go/issues/9369#issuecomment-69864440
-GOFLAGS += -installsuffix netgo
 LDFLAGS += -extldflags "-static"
 endif
 


### PR DESCRIPTION
I don't think we need it anymore, and the suffix is making teamcity builds unhappy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/83)
<!-- Reviewable:end -->
