### PR TITLE
block_writer: only exit on SIGINT and SIGTERM

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -219,7 +219,7 @@ func main() {
 	var numErr int
 	tick := time.Tick(*outputInterval)
 	done := make(chan os.Signal, 3)
-	signal.Notify(done)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		wg.Wait()


### PR DESCRIPTION
Previously block_writer was exiting when any signal was received. For
example, if the remote node it was talking to terminated abruptly
block_writer could receive a SIGPIPE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/86)
<!-- Reviewable:end -->
