### PR TITLE
block_writer: add p{50,95,99,max} latency stats

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -36,6 +36,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/codahale/hdrhistogram"
 	"github.com/satori/go.uuid"
 	// Import postgres driver.
 	_ "github.com/lib/pq"
@@ -70,24 +71,30 @@ var benchmarkName = flag.String("benchmark-name", "BenchmarkBlockWriter", "Test 
 // numBlocks keeps a global count of successfully written blocks.
 var numBlocks uint64
 
-// A blockWriter writes blocks of random data into cockroach in an infinite
-// loop.
 type blockWriter struct {
-	db   *sql.DB
-	rand *rand.Rand
+	db      *sql.DB
+	rand    *rand.Rand
+	latency struct {
+		sync.Mutex
+		*hdrhistogram.WindowedHistogram
+	}
 }
 
-func newBlockWriter(db *sql.DB) blockWriter {
-	source := rand.NewSource(int64(time.Now().UnixNano()))
-	return blockWriter{
+func newBlockWriter(db *sql.DB) *blockWriter {
+	bw := &blockWriter{
 		db:   db,
-		rand: rand.New(source),
+		rand: rand.New(rand.NewSource(int64(time.Now().UnixNano()))),
 	}
+	bw.latency.WindowedHistogram = hdrhistogram.NewWindowed(1,
+		(100 * time.Microsecond).Nanoseconds(),
+		(10 * time.Second).Nanoseconds(),
+		1)
+	return bw
 }
 
 // run is an infinite loop in which the blockWriter continuously attempts to
 // write blocks of random data into a table in cockroach DB.
-func (bw blockWriter) run(errCh chan<- error, wg *sync.WaitGroup) {
+func (bw *blockWriter) run(errCh chan<- error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	id := uuid.NewV4().String()
@@ -108,9 +115,16 @@ func (bw blockWriter) run(errCh chan<- error, wg *sync.WaitGroup) {
 			fmt.Fprintf(&buf, ` (%d, '%s', %d, $%d)`, blockID, id, blockCount, i+1)
 		}
 
+		start := time.Now()
 		if _, err := bw.db.Exec(buf.String(), args...); err != nil {
 			errCh <- err
 		} else {
+			elapsed := time.Since(start)
+			bw.latency.Lock()
+			if err := bw.latency.Current.RecordValue(elapsed.Nanoseconds()); err != nil {
+				log.Fatal(err)
+			}
+			bw.latency.Unlock()
 			v := atomic.AddUint64(&numBlocks, uint64(*batch))
 			if *maxBlocks > 0 && v >= *maxBlocks {
 				return
@@ -119,9 +133,7 @@ func (bw blockWriter) run(errCh chan<- error, wg *sync.WaitGroup) {
 	}
 }
 
-// randomBlock generates a slice of randomized bytes. Random data is preferred
-// to prevent compression in storage.
-func (bw blockWriter) randomBlock() []byte {
+func (bw *blockWriter) randomBlock() []byte {
 	blockSize := bw.rand.Intn(*maxBlockSizeBytes-*minBlockSizeBytes) + *minBlockSizeBytes
 	blockData := make([]byte, blockSize)
 	for i := range blockData {
@@ -217,7 +229,7 @@ func main() {
 	lastNow := time.Now()
 	start := lastNow
 	var lastBlocks uint64
-	writers := make([]blockWriter, *concurrency)
+	writers := make([]*blockWriter, *concurrency)
 
 	errCh := make(chan error)
 	var wg sync.WaitGroup
@@ -251,7 +263,7 @@ func main() {
 			*benchmarkName, numBlocks, float64(elapsed.Nanoseconds())/float64(numBlocks))
 	}()
 
-	for i := 0; true; {
+	for i := 0; ; {
 		select {
 		case err := <-errCh:
 			numErr++
@@ -263,18 +275,40 @@ func main() {
 			continue
 
 		case <-tick:
+			var h *hdrhistogram.Histogram
+			for _, w := range writers {
+				w.latency.Lock()
+				m := w.latency.Merge()
+				w.latency.Rotate()
+				w.latency.Unlock()
+				if h == nil {
+					h = m
+				} else {
+					h.Merge(m)
+				}
+			}
+
+			p50 := h.ValueAtQuantile(50)
+			p95 := h.ValueAtQuantile(95)
+			p99 := h.ValueAtQuantile(99)
+			pMax := h.ValueAtQuantile(100)
+
 			now := time.Now()
 			elapsed := time.Since(lastNow)
 			blocks := atomic.LoadUint64(&numBlocks)
 			if i%20 == 0 {
-				fmt.Println("_elapsed___errors__ops/sec(inst)___ops/sec(cum)")
+				fmt.Println("_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)")
 			}
 			i++
-			fmt.Printf("%8s %8d %14.1f %14.1f\n",
+			fmt.Printf("%8s %8d %14.1f %14.1f %8.1f %8.1f %8.1f %8.1f\n",
 				time.Duration(time.Since(start).Seconds()+0.5)*time.Second,
 				numErr,
 				float64(blocks-lastBlocks)/elapsed.Seconds(),
-				float64(blocks)/time.Since(start).Seconds())
+				float64(blocks)/time.Since(start).Seconds(),
+				time.Duration(p50).Seconds()*1000,
+				time.Duration(p95).Seconds()*1000,
+				time.Duration(p99).Seconds()*1000,
+				time.Duration(pMax).Seconds()*1000)
 			lastBlocks = blocks
 			lastNow = now
 


### PR DESCRIPTION
Latency is measured over the reporting interval (1s).

```
_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
      1s        0         5689.5         5689.4      2.5      4.7      5.8     10.5
      2s        0         4903.8         5297.8      2.9      6.0      7.6     16.8
      3s        0         5297.6         5297.7      2.6      6.0      8.4     16.8
      4s        0         4776.6         5167.5      2.9      7.1     10.0     13.6
      5s        0         4759.7         5086.1      2.9      7.3     11.0     14.2
      6s        0         4945.3         5062.7      2.8      6.6     10.5     14.2
      7s        0         4768.4         5020.8      2.8      7.1     14.2     22.0
      8s        0         4914.9         5007.5      2.8      6.8     12.1     18.9
      9s        0         4258.1         4924.2      2.9      8.9     14.7     19.9
     10s        0         4598.5         4891.7      2.9      6.3     14.2     23.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/93)
<!-- Reviewable:end -->
