### PR TITLE
Add shorturl example.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deps:
 	$(GO) get -d -t ./...
 
 .PHONY: build
-build: deps block_writer fakerealtime filesystem bank photos
+build: deps block_writer fakerealtime filesystem bank photos shorturl
 
 .PHONY: block_writer
 block_writer:
@@ -72,6 +72,10 @@ ledger:
 .PHONY: photos
 photos:
 	$(GO) build -tags '$(TAGS)' $(GOFLAGS) -ldflags '$(LDFLAGS)' -v -i -o photos/photos ./photos
+
+.PHONY: shorturl
+shorturl:
+	$(GO) build -tags '$(TAGS)' $(GOFLAGS) -ldflags '$(LDFLAGS)' -v -i -o shorturl/shorturl ./shorturl
 
 .PHONY: check
 check:

--- a/build/build-examples.sh
+++ b/build/build-examples.sh
@@ -6,7 +6,7 @@
 set -eux
 
 time make deps
-for proj in bank ledger block_writer fakerealtime filesystem photos; do
+for proj in bank ledger block_writer fakerealtime filesystem photos shorturl; do
   time make STATIC=1 ${proj}
   strip -S ${proj}/${proj}
 done

--- a/build/push-aws.sh
+++ b/build/push-aws.sh
@@ -39,6 +39,6 @@ function push_one_binary {
   rm -f ${tmpfile}
 }
 
-for proj in bank ledger block_writer fakerealtime filesystem photos; do
+for proj in bank ledger block_writer fakerealtime filesystem photos shorturl; do
   push_one_binary ${proj}/${proj}
 done

--- a/shorturl/.gitignore
+++ b/shorturl/.gitignore
@@ -1,0 +1,1 @@
+shorturl

--- a/shorturl/db.go
+++ b/shorturl/db.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	// Import postgres driver.
+	_ "github.com/lib/pq"
+)
+
+var shortyDB *sql.DB
+
+const (
+	urlTableSchema = `
+	  CREATE TABLE IF NOT EXISTS urls (
+			id STRING PRIMARY KEY,
+			url STRING DEFAULT '' NOT NULL,
+			reserved BOOL DEFAULT FALSE NOT NULL,
+			custom BOOL DEFAULT FALSE NOT NULL,
+			public BOOL DEFAULT FALSE NOT NULL,
+			date_added TIMESTAMP DEFAULT CLOCK_TIMESTAMP() NOT NULL,
+			added_by STRING DEFAULT '' NOT NULL
+		)`
+
+	counterTableSchema = `
+	  CREATE TABLE IF NOT EXISTS counters (
+			id STRING PRIMARY KEY,
+			counter INT NOT NULL
+		)`
+
+	counterName = "CURRENT"
+)
+
+// SetupDB initializes the DB object.
+func SetupDB(dbURL string) error {
+	parsedURL, err := url.Parse(dbURL)
+	if err != nil {
+		return err
+	}
+
+	if len(parsedURL.Path) == 1 {
+		return fmt.Errorf("connection url must specify database name")
+	}
+
+	dbName := parsedURL.Path[1:]
+	log.Printf("Using database: %s", dbName)
+
+	// Open connection to server and create a database.
+	db, err := sql.Open("postgres", parsedURL.String())
+	if err != nil {
+		return err
+	}
+
+	if *createDB {
+		if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName)); err != nil {
+			return err
+		}
+	}
+
+	if *dropDB {
+		if _, err := db.Exec(`DROP TABLE IF EXISTS urls`); err != nil {
+			return err
+		}
+		if _, err := db.Exec(`DROP TABLE IF EXISTS counters`); err != nil {
+			return err
+		}
+	}
+
+	if _, err := db.Exec(urlTableSchema); err != nil {
+		return err
+	}
+
+	if _, err := db.Exec(counterTableSchema); err != nil {
+		return err
+	}
+
+	// Write the first counter if not present.
+	// We intentionally fail on errors other than "duplicate key".
+	if _, err := db.Exec(`INSERT INTO counters VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+		counterName, checkParseCounter(initialCounter)); err != nil {
+		return err
+	}
+
+	// Write all reserved shortys.
+	// WARNING: if new ones are added, they may overwrite existing shortys.
+	for s := range reservedShortys {
+		if _, err := db.Exec(`INSERT INTO urls (id, reserved) VALUES ($1, TRUE) ON CONFLICT (id) DO UPDATE SET reserved = TRUE`,
+			s); err != nil {
+			return err
+		}
+	}
+
+	shortyDB = db
+	return nil
+}
+
+// sqlExecutor is an interface needed for basic queries.
+// It is implemented by both sql.DB and sql.Txn.
+type sqlExecutor interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+}
+
+func getShorty(shortURL string) (*Shorty, error) {
+	if shortyDB == nil {
+		log.Fatal("getShorty called before DB setup")
+	}
+	if err := validateShortURL(shortURL); err != nil {
+		return nil, err
+	}
+	res := &Shorty{ShortURL: shortURL}
+	err := shortyDB.QueryRow(
+		`SELECT url, reserved, custom, public, date_added, added_by FROM urls WHERE id = $1`,
+		shortURL).Scan(&res.LongURL,
+		&res.Reserved,
+		&res.Custom,
+		&res.Public,
+		&res.DateAdded,
+		&res.AddedBy)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Reserved is the same as "not found"
+	if res.Reserved {
+		return nil, nil
+	}
+
+	return res, nil
+}
+
+// getShortysByOwner returns the list of shortys that have
+// an 'added by' field matching 'owner'.
+// Specify the empty string to get anonymous shortys.
+// Does not return "reserved" keys.
+// TODO(marc): we should make an index for this.
+func getShortysByOwner(owner string) ([]*Shorty, error) {
+	res := make([]*Shorty, 0, 0)
+	rows, err := shortyDB.Query(`SELECT id, url, public, date_added FROM urls WHERE added_by = $1 AND reserved = false ORDER BY date_added DESC`,
+		owner)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		shorty := &Shorty{}
+		if err := rows.Scan(&shorty.ShortURL, &shorty.LongURL, &shorty.Public, &shorty.DateAdded); err != nil {
+			return nil, err
+		}
+		res = append(res, shorty)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func getCounter(e sqlExecutor) (int64, error) {
+	var counter int64
+	err := e.QueryRow(`SELECT counter FROM counters WHERE id = $1`, counterName).Scan(&counter)
+	return counter, err
+}
+
+func saveCounter(e sqlExecutor, counter int64) error {
+	_, err := e.Exec(`UPDATE counters SET counter = $1 WHERE id = $2`, counter, counterName)
+	return err
+}
+
+func shortyExists(e sqlExecutor, shortURL string) (bool, error) {
+	var exists bool
+	err := e.QueryRow(`SELECT EXISTS (SELECT id FROM urls WHERE id = $1)`, shortURL).Scan(&exists)
+	return exists, err
+}
+
+func insertShorty(e sqlExecutor, shorty Shorty) error {
+	_, err := e.Exec(`INSERT INTO urls (id, url, custom, public, added_by) VALUES ($1, $2, $3, $4, $5)`,
+		shorty.ShortURL,
+		shorty.LongURL,
+		shorty.Custom,
+		shorty.Public,
+		shorty.AddedBy)
+	return err
+}
+
+func addNewShorty(shorty Shorty) (string, error) {
+	isCustom := shorty.Custom
+	txErr := crdb.ExecuteTx(shortyDB, func(tx *sql.Tx) error {
+		var err error
+		var counter int64
+		if !isCustom {
+			// Initialize counter for automatic generation.
+			if counter, err = getCounter(tx); err != nil {
+				return err
+			}
+		}
+
+		for {
+			if !isCustom {
+				// Make URL from counter.
+				shorty.ShortURL = counterFromInt(counter)
+				counter++
+			}
+
+			// Check if the short URL exists.
+			var exists bool
+			if exists, err = shortyExists(tx, shorty.ShortURL); err != nil {
+				return err
+			} else if exists {
+				if isCustom {
+					return fmt.Errorf("short URL %s already exists", shorty.ShortURL)
+				}
+				continue
+			}
+
+			// Insert new URL.
+			if err = insertShorty(tx, shorty); err != nil {
+				return err
+			}
+
+			if !isCustom {
+				// Make sure we save the latest counter.
+				if err := saveCounter(tx, counter); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	})
+
+	if txErr != nil {
+		return "", txErr
+	}
+
+	return shorty.ShortURL, nil
+}

--- a/shorturl/handlers.go
+++ b/shorturl/handlers.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+var (
+	validSchemeRE = regexp.MustCompile(`^http(s)?$`)
+)
+
+// SetupHandlers sets up the http handlers.
+func SetupHandlers() {
+	http.HandleFunc("/", handleRoot)
+	http.HandleFunc(fmt.Sprintf("/%s", publicSubDir), handlePublic)
+}
+
+func handlePublic(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if len(req.URL.RawQuery) != 0 {
+		// No query parameters allowed on public URL.
+		// This still lets through '/pub/<something>?'
+		http.Error(rw, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	path := req.URL.Path[len(publicSubDir)+1:]
+	handleRedirect(rw, req, path, true /* isPublic */)
+}
+
+func handleRoot(rw http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	if path == "/" {
+		handleSettings(rw, req)
+		return
+	}
+	path = path[1:]
+	handleRedirect(rw, req, path, false /* isPublic */)
+}
+
+func handleRedirect(rw http.ResponseWriter, req *http.Request, shortURL string, isPublic bool) {
+	if err := validateShortURL(shortURL); err != nil {
+		http.Error(rw, "invalid short URL", http.StatusBadRequest)
+		return
+	}
+
+	shorty, err := getShorty(shortURL)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if shorty == nil || (isPublic && !shorty.Public) {
+		http.Error(rw, fmt.Sprintf("short URL %q not found", shortURL), http.StatusNotFound)
+		return
+	}
+
+	http.Redirect(rw, req, shorty.LongURL, http.StatusFound)
+}
+
+func handleSettings(rw http.ResponseWriter, req *http.Request) {
+	query := req.URL.Query()
+	mode := query.Get("mode")
+	switch mode {
+	case "":
+		handleNew(rw, req)
+	case "view":
+		handleView(rw, req, query)
+	case "create":
+		handleCreate(rw, req)
+	default:
+		http.Error(rw, fmt.Sprintf("unknown operation: %s", mode), http.StatusBadRequest)
+	}
+	return
+}
+
+func handleNew(rw http.ResponseWriter, req *http.Request) {
+	if err := showCreateForm(rw); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Display my own shortys, don't fail on errors.
+	email := req.Header.Get("X-Forwarded-Email")
+	myShortys, err := getShortysByOwner(email)
+	if err != nil {
+		log.Printf("Error getting shortys by owner(%s): %v", email, err)
+		return
+	}
+
+	if err := viewMyShortys(rw, myShortys); err != nil {
+		log.Printf("Error displaying shortys by owner(%s): %v", email, err)
+		return
+	}
+}
+
+func handleCreate(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	email := req.Header.Get("X-Forwarded-Email")
+	if *requireEmail && len(email) == 0 {
+		http.Error(rw, "missing X-Forwarded-Email header", http.StatusUnauthorized)
+		return
+	}
+
+	shortURL := req.PostFormValue("short")
+	if len(shortURL) != 0 {
+		if err := validateShortURL(shortURL); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Parse and rewrite the url.
+	longURL := req.PostFormValue("url")
+	if len(longURL) == 0 {
+		http.Error(rw, "no URL specified", http.StatusBadRequest)
+		return
+	}
+
+	parsedURL, err := url.Parse(longURL)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("invalid URL: %v", err), http.StatusBadRequest)
+		return
+	}
+	if len(parsedURL.Host) == 0 ||
+		len(parsedURL.Scheme) == 0 || !validSchemeRE.MatchString(parsedURL.Scheme) {
+		http.Error(rw, "URL needs to be of the form http(s)://hostname.com", http.StatusBadRequest)
+		return
+	}
+
+	shorty := Shorty{
+		ShortURL: shortURL,
+		LongURL:  parsedURL.String(),
+		Custom:   len(shortURL) != 0,
+		Public:   req.PostFormValue("public") == "on",
+		AddedBy:  email,
+	}
+
+	newShortURL, err := addNewShorty(shorty)
+	if err != nil {
+		// We're assuming "bad request" here, but it could also be an internal error.
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Redirect to the viewer for confirmation:
+	http.Redirect(rw, req, fmt.Sprintf("/?mode=view&url=%s", newShortURL), http.StatusFound)
+}
+
+func handleView(rw http.ResponseWriter, req *http.Request, query url.Values) {
+	if req.Method != http.MethodGet {
+		http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	shortURL := query.Get("url")
+	if len(shortURL) == 0 {
+		http.Error(rw, "empty short URL requested", http.StatusBadRequest)
+		return
+	}
+
+	if err := validateShortURL(shortURL); err != nil {
+		http.Error(rw, "invalid short URL", http.StatusBadRequest)
+		return
+	}
+
+	shorty, err := getShorty(shortURL)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if shorty == nil {
+		http.Error(rw, fmt.Sprintf("short URL %q not found", shortURL), http.StatusNotFound)
+		return
+	}
+
+	if err := viewShorty(rw, shorty); err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/shorturl/main.go
+++ b/shorturl/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+var httpHost = flag.String("host", "localhost", "Interface host to listen on")
+var httpPort = flag.Int("port", 8080, "Port to listen on")
+
+var createDB = flag.Bool("create", true, "Attempt to create the DB if it does not exist. Root required.")
+var dropDB = flag.Bool("drop", false, "Drop tables at startup")
+
+var requireEmail = flag.Bool("require-email", true, "Require X-Forwarded-Email for modifications")
+
+const (
+	publicSubDir = "pub/"
+	defaultDBURL = "postgresql://root@localhost:26257/shorty?sslmode=disable"
+)
+
+var usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  %s <db URL>\n\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	dbURL := defaultDBURL
+	if flag.NArg() == 1 {
+		dbURL = flag.Arg(0)
+	}
+
+	if err := SetupDB(dbURL); err != nil {
+		log.Fatal(err)
+	}
+
+	SetupHandlers()
+
+	hostAddr := fmt.Sprintf("%s:%d", *httpHost, *httpPort)
+	log.Printf("Starting http server on %s", hostAddr)
+	log.Fatal(http.ListenAndServe(hostAddr, nil))
+}

--- a/shorturl/main.go
+++ b/shorturl/main.go
@@ -6,6 +6,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+
+	// Hook up profiling handlers.
+	_ "net/http/pprof"
 )
 
 var httpHost = flag.String("host", "localhost", "Interface host to listen on")

--- a/shorturl/main_test.go
+++ b/shorturl/main_test.go
@@ -1,0 +1,145 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Marc Berhault (marc@cockroachlabs.com)
+
+package main
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach-go/testserver"
+)
+
+func initTestDB(t *testing.T) func() {
+	ts, err := testserver.NewTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ts.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url, err := ts.PGURL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	url.Path = "testshorty"
+
+	*createDB = true
+	if err := SetupDB(url.String()); err != nil {
+		ts.Stop()
+		t.Fatal(err)
+	}
+
+	return ts.Stop
+}
+
+func TestCounter(t *testing.T) {
+	stop := initTestDB(t)
+	defer stop()
+
+	// Check the initial counter.
+	c, err := getCounter(shortyDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCounter := checkParseCounter(initialCounter)
+	if c != expectedCounter {
+		t.Fatalf("expected initial counter of %d, got %d", expectedCounter, c)
+	}
+
+	expectedShortURL := counterFromInt(expectedCounter)
+	// Add a single entry with automatic URL.
+	newURL, err := addNewShorty(Shorty{
+		ShortURL: "",
+		LongURL:  "https://www.google.com",
+		Custom:   false,
+		Public:   true,
+		AddedBy:  "shorty tester",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCounter++
+
+	if newURL != expectedShortURL {
+		t.Fatalf("expected new shorty URL of %s, got %s", expectedShortURL, newURL)
+	}
+
+	if c, err = getCounter(shortyDB); err != nil {
+		t.Fatal(err)
+	}
+
+	if c != expectedCounter {
+		t.Fatalf("expected new counter of %d, got %d", expectedCounter, c)
+	}
+
+	// Insert a custom URL right at the next counter.
+	expectedShortURL = counterFromInt(expectedCounter)
+	newURL, err = addNewShorty(Shorty{
+		ShortURL: expectedShortURL,
+		LongURL:  "https://www.google.com",
+		Custom:   true,
+		Public:   true,
+		AddedBy:  "shorty tester",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if newURL != expectedShortURL {
+		t.Fatalf("expected new shorty URL of %s, got %s", expectedShortURL, newURL)
+	}
+
+	// Check counter, it shouldn't have changed.
+	if c, err = getCounter(shortyDB); err != nil {
+		t.Fatal(err)
+	}
+
+	if c != expectedCounter {
+		t.Fatalf("expected new counter of %d, got %d", expectedCounter, c)
+	}
+
+	// Now insert another automatic URL, this should skip one counter value.
+	expectedCounter++
+	expectedShortURL = counterFromInt(expectedCounter)
+	// Add a single entry with automatic URL.
+	newURL, err = addNewShorty(Shorty{
+		ShortURL: "",
+		LongURL:  "https://www.google.com",
+		Custom:   false,
+		Public:   true,
+		AddedBy:  "shorty tester",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCounter++
+
+	if newURL != expectedShortURL {
+		t.Fatalf("expected new shorty URL of %s, got %s", expectedShortURL, newURL)
+	}
+
+	if c, err = getCounter(shortyDB); err != nil {
+		t.Fatal(err)
+	}
+
+	if c != expectedCounter {
+		t.Fatalf("expected new counter of %d, got %d", expectedCounter, c)
+	}
+
+}

--- a/shorturl/shorty.go
+++ b/shorturl/shorty.go
@@ -20,7 +20,8 @@ const (
 var (
 	validShortyRE   = regexp.MustCompile(fmt.Sprintf(`^[%s]+$`, validChars))
 	reservedShortys = map[string]struct{}{
-		"pub": {},
+		"debug": {}, // pprof endpoint.
+		"pub":   {}, // Public endpoint.
 	}
 )
 

--- a/shorturl/shorty.go
+++ b/shorturl/shorty.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+const (
+	// the first auto shorty: reserve all urls < 5 chars.
+	initialCounter = "10000"
+	// allowed characters (for custom shortys). This needs to work as part
+	// of `validShortyRE` below.
+	validChars      = "0123456789abcdefghijklmnopqrstuvwxyz_-"
+	shortyMaxLength = 20
+)
+
+var (
+	validShortyRE   = regexp.MustCompile(fmt.Sprintf(`^[%s]+$`, validChars))
+	reservedShortys = map[string]struct{}{
+		"pub": {},
+	}
+)
+
+// validateCounter returns an error if the counter fails parsing.
+func validateCounter(c string) error {
+	_, err := parseCounter(c)
+	return err
+}
+
+// parseCounter parses a string counter into an integer.
+func parseCounter(c string) (int64, error) {
+	return strconv.ParseInt(c, 36, 64)
+}
+
+// checkParseCounter parses a counter and crashes on errors.
+func checkParseCounter(c string) int64 {
+	ret, err := parseCounter(c)
+	if err != nil {
+		log.Fatalf("failed to parse counter %q: %v", c, err)
+	}
+	return ret
+}
+
+func counterFromInt(c int64) string {
+	return strconv.FormatInt(c, 36)
+}
+
+// validateShortURL verifies that a short URL is valid.
+func validateShortURL(s string) error {
+	if len(s) == 0 {
+		return fmt.Errorf("short URL cannot be blank")
+	}
+	if len(s) > shortyMaxLength {
+		return fmt.Errorf("short URL cannot be longer than %d characters", shortyMaxLength)
+	}
+	if !validShortyRE.MatchString(s) {
+		return fmt.Errorf("short URL must only contain the characters: %q", validChars)
+	}
+	return nil
+}
+
+type Shorty struct {
+	ShortURL  string
+	LongURL   string
+	Reserved  bool
+	Custom    bool
+	Public    bool
+	DateAdded time.Time
+	AddedBy   string
+}

--- a/shorturl/templates.go
+++ b/shorturl/templates.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+)
+
+var (
+	templateView     *template.Template
+	templateCreate   *template.Template
+	templateViewMine *template.Template
+)
+
+const (
+	templateViewText = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Shorty: {{.ShortURL}}</title>
+	</head>
+	<body>
+  	<h3>Shorty URL: {{.ShortURL}}</h3>
+	  <table border=0>
+			<tr>
+			  <td>ShortURL</td>
+				<td>{{.ShortURL}}</td>
+			</tr>
+			<tr>
+			  <td>LongURL</td>
+				<td>{{.LongURL}}</td>
+			</tr>
+			<tr>
+			  <td>Public</td>
+				<td>{{.Public}}</td>
+			</tr>
+			<tr>
+			  <td>Custom</td>
+				<td>{{.Custom}}</td>
+			</tr>
+			<tr>
+			  <td>Added</td>
+				<td>{{.DateAdded.Format "Mon Jan 2 15:04:05"}}</td>
+			</tr>
+			<tr>
+	      <td>Owner</td>
+				<td>{{.AddedBy}}</td>
+			</tr>
+		</table>
+		<br>
+	</body>
+</html>`
+
+	templateCreateText = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Shorty</title>
+	</head>
+	<body>
+	  <h3>Create URL:</h3>
+	  <form action="/?mode=create" method="post">
+	  <table border=0>
+		  <tr>
+		      <td>LongURL</td>
+					<td><input type="text" name="url" size=100></td>
+			</tr>
+			<tr>
+			    <td>Pick automatically</td>
+					<td><input type="checkbox" id="custom" checked></td>
+			</tr>
+	    <script type="text/javascript">
+			  document.getElementById("custom").onchange = function() {
+						shortBox = document.getElementById("short")
+						shortBox.disabled=this.checked
+						shortBox.value = ""
+				}
+				this.checked = true
+		</script>
+			<tr>
+	        <td>ShortURL</td>
+					<td><input type="text" name="short" id="short" disabled></td>
+			</tr>
+			<tr>
+		      <td>Public</td>
+					<td><input type="checkbox" name="public"></td>
+			</tr>
+			<tr>
+		      <td><input type="submit" value="Submit"></td>
+			</tr>
+		</table>
+		</form>
+		<br>
+	</body>
+</html>`
+
+	templateViewMineText = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>Shorty: my URLs</title>
+	</head>
+	<body>
+		<h3>My URLs:</h3>
+	  <table border=0>
+			<tr>
+			  <td><b>ShortURL</b></td>
+			  <td><b>LongURL</b></td>
+			  <td><b>Public</b></td>
+			  <td><b>Added</b></td>
+			</tr>
+
+			{{range .}}
+			<tr>
+				<td>{{.ShortURL}}</td>
+				<td>{{.LongURL}}</td>
+				<td>{{.Public}}</td>
+				<td>{{.DateAdded.Format "Mon Jan 2 15:04:05"}}</td>
+			</tr>
+			{{end}}
+		</table>
+	  <br>
+	</body>
+</html>`
+)
+
+func init() {
+	var err error
+	if templateView, err = template.New("view").Parse(templateViewText); err != nil {
+		log.Fatalf("error parsing view template: %v", err)
+	}
+
+	if templateCreate, err = template.New("create").Parse(templateCreateText); err != nil {
+		log.Fatalf("error parsing create template: %v", err)
+	}
+
+	if templateViewMine, err = template.New("view mine").Parse(templateViewMineText); err != nil {
+		log.Fatalf("error parsing view-mine template: %v", err)
+	}
+}
+
+func viewShorty(rw http.ResponseWriter, shorty *Shorty) error {
+	return templateView.Execute(rw, shorty)
+}
+
+func showCreateForm(rw http.ResponseWriter) error {
+	return templateCreate.Execute(rw, nil)
+}
+
+func viewMyShortys(rw http.ResponseWriter, shortys []*Shorty) error {
+	return templateViewMine.Execute(rw, shortys)
+}


### PR DESCRIPTION
This has two endpoints:
* `/`
  * no path/query: shows "create url" form
  * path: [0-9a-z.-_~]+ redirects to url pointed to for shorturl
  * ?mode=view&url=<X>: display properties for short url X
  * ?mode=create: endpoint for the creation form
* `/pub/<x>`
  * public redirect (no `X-FORWARDED-EMAIL` required), only redirects
    short URLs marked `public`

This runs on `https://crdb.io`, behind oauth_proxy accepting cockroachlabs gmail accounts.
The `/pub/` URI is whitelisted, bypassing oauth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/examples-go/97)
<!-- Reviewable:end -->
