### PR TITLE
block_writer: update for breaking change in satori/go.uuid API

### DIFF
--- a/block_writer/main.go
+++ b/block_writer/main.go
@@ -112,7 +112,7 @@ func newBlockWriter(db *sql.DB) *blockWriter {
 func (bw *blockWriter) run(errCh chan<- error, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	id := uuid.NewV4().String()
+	id := uuid.Must(uuid.NewV4()).String()
 	var blockCount uint64
 
 	for {


### PR DESCRIPTION
As mentioned at https://github.com/satori/go.uuid/issues/66, the satori/go.uuid API changed, so the call to `uuid.NewV4` needs to be wrapped in `uuid.Must`.