### PR TITLE
add option to use upsert instead of update

### DIFF
--- a/bank2/main.go
+++ b/bank2/main.go
@@ -117,7 +117,7 @@ func moveMoney(db *sql.DB, aggr *measurement) {
 			if *updatemethod == "update" {
 				updateAcct = `UPDATE account SET balance = $1 WHERE id = $2`				
 			} else {
-				updateAcct = `INSERT into account (balance,id) values ($1,$2) on conflict (id) do update set balance = excluded.balance`				
+				updateAcct = `INSERT into account (balance,id) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET balance = excluded.balance`				
 			}
 			if *parallelStmts {
 				const parallelize = ` RETURNING NOTHING`

--- a/bank2/main.go
+++ b/bank2/main.go
@@ -40,6 +40,7 @@ var numTransfers = flag.Int("num-transfers", 0, "Number of transfers (0 to conti
 var numAccounts = flag.Int("num-accounts", 100, "Number of accounts.")
 var concurrency = flag.Int("concurrency", 16, "Number of concurrent actors moving money.")
 var contention = flag.String("contention", "low", "Contention model {low | high}.")
+var updatemethod = flag.String("updatemethod", "update", "update or upsert DML {update | upsert}.")
 var balanceCheckInterval = flag.Duration("balance-check-interval", time.Second, "Interval of balance check.")
 var parallelStmts = flag.Bool("parallel-stmts", false, "Run independent statements in parallel.")
 
@@ -112,7 +113,12 @@ func moveMoney(db *sql.DB, aggr *measurement) {
 			}
 			insertTxn := `INSERT INTO transaction (id, txn_ref) VALUES ($1, $2)`
 			insertTxnLeg := `INSERT INTO transaction_leg (account_id, amount, running_balance, txn_id) VALUES ($1, $2, $3, $4)`
-			updateAcct := `UPDATE account SET balance = $1 WHERE id = $2`
+			var updateAcct string
+			if *updatemethod == "update" {
+				updateAcct = `UPDATE account SET balance = $1 WHERE id = $2`				
+			} else {
+				updateAcct = `INSERT into account (balance,id) values ($1,$2) on conflict (id) do update set balance = excluded.balance`				
+			}
 			if *parallelStmts {
 				const parallelize = ` RETURNING NOTHING`
 				insertTxn += parallelize


### PR DESCRIPTION
allows performance of comparison of two DML methods (update vs upsert) to achieve the same result.  multi-row capability of upsert should make upsert faster.  This is an initial PR to add update vs upsert 

graph of 4 iterations 

./bank2 --contention high postgres://root@localhost:26257?sslmode=disable
./bank2 --updatemethod upsert --contention high postgres://root@localhost:26257?sslmode=disable
./bank2 --contention high postgres://root@localhost:26257?sslmode=disable
./bank2 --updatemethod upsert --contention high postgres://root@localhost:26257?sslmode=disable

<img width="1280" alt="screen shot 2018-08-08 at 6 49 04 pm" src="https://user-images.githubusercontent.com/6315124/43868472-c95fa4a8-9b3b-11e8-9bc6-18514c0f76e9.png">